### PR TITLE
[修正] page lengthに関するエラー

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,16 +48,12 @@ export default {
       `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
     ).then((res) => {
       const pageSize = 10;
-      var p_length = 1;
-      if (!!(res.data.messages.length)) {
-        p_length = Math.ceil(res.data.messages.length / pageSize);
-      }
       return {
         messages: res.data.messages,
         page: 1,
         pageSize: pageSize,
         displayMessages: res.data.messages.slice(0, pageSize),
-        pageLength: p_length,
+        pageLength: Math.ceil(res.data.messages.length / pageSize),
         threadShow: false,
         threadMessages: [],
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-layout>
     <v-flex>
-      <message-card 
+      <message-card
         v-for="message in displayMessages"
         v-bind:message="message"
         v-bind:isThread=false
@@ -23,7 +23,7 @@
         </v-btn>
       </div>
       <br>
-      <message-card 
+      <message-card
         v-for="message in threadMessages"
         v-bind:message="message"
         v-bind:isThread=true
@@ -40,17 +40,24 @@ export default {
   components: {
     MessageCard
   },
+  data: function () {
+    return { pageLength: 1}
+  },
   async asyncData ({ $axios }) {
     return $axios.get(
       `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
     ).then((res) => {
       const pageSize = 10;
-      return { 
+      var p_length = 1;
+      if (!!(res.data.messages.length)) {
+        p_length = Math.ceil(res.data.messages.length / pageSize);
+      }
+      return {
         messages: res.data.messages,
         page: 1,
         pageSize: pageSize,
         displayMessages: res.data.messages.slice(0, pageSize),
-        pageLength: res.data.messages.length / pageSize,
+        pageLength: p_length,
         threadShow: false,
         threadMessages: [],
       }


### PR DESCRIPTION
## 概要
ページをロードするたびにエラーが出ていたものの修正をしました。

```
 ERROR  [Vue warn]: Invalid prop: custom validator check failed for prop "length".                                                                                                                          18:58:35

found in

---> <VPagination>
       <Pages/index.vue> at pages/index.vue
         <Nuxt>
           <VContent>
             <VApp>
               <Layouts/default.vue> at layouts/default.vue
                 <Root>
```
こちらのエラーが出ないようにしました。

## 原因
- ブラウザのページネーションのページ数の最大を決める数式が `res.data.messages.length / pageSize`となっており、メッセージ数によっては式の結果がfloatがになっていました。
  - page lengthは整数(Number)である必要があります。(型が指定されていて、バリデーションが行われています。)

## 修正方法
- `res.data.messages.length / pageSize` を Math.ceil(res.data.messages.length / pageSize)にしました。
  - 数式の結果の小数点以下を切り上げて整数にしました。