### PR TITLE
UserID => UserName (ex. UAJKSdNV1 => Taku Sakikawa)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+CHANNEL_ID=チャンネルのID
+SLACK_API_TOKEN=秘匿情報を参照

--- a/components/MessageCard.vue
+++ b/components/MessageCard.vue
@@ -58,19 +58,6 @@ export default {
     replaceLinkWithATag(actualLink, displayLink){
       return `<a href="${actualLink}" target="_blank">${displayLink || actualLink}</a>`
     },
-
-    getUserName(userId){
-      this.$axios.get(
-        `https://slack.com/api/users.info?token=${process.env.SLACK_API_TOKEN}&user=${userId}`)
-        .then(response => {
-          if(response.data.ok == false) {
-            alert(response.data.error)
-            return;
-          }
-          return response.data.user.profile.display_name;
-        })
-        .catch(error => alert(error));
-    }
   },
 }
 </script>

--- a/components/MessageCard.vue
+++ b/components/MessageCard.vue
@@ -54,9 +54,23 @@ export default {
     showThread() {
       this.$emit('showThread', this.message.ts);
     },
+
     replaceLinkWithATag(actualLink, displayLink){
       return `<a href="${actualLink}" target="_blank">${displayLink || actualLink}</a>`
     },
+
+    getUserName(userId){
+      this.$axios.get(
+        `https://slack.com/api/users.info?token=${process.env.SLACK_API_TOKEN}&user=${userId}`)
+        .then(response => {
+          if(response.data.ok == false) {
+            alert(response.data.error)
+            return;
+          }
+          return response.data.user.profile.display_name;
+        })
+        .catch(error => alert(error));
+    }
   },
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -51,80 +51,89 @@ export default {
   },
 
   async asyncData ({ $axios }) {
+
+    // return await $axios.get(
+    //   `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
+    // ).then((res) => {
+    //   const pageSize = 10;
+    //   return {
+    //     messages: res.data.messages,
+    //     page: 1,
+    //     pageSize: pageSize,
+    //     displayMessages: res.data.messages.slice(0, pageSize),
+    //     pageLength: Math.ceil(res.data.messages.length / pageSize),
+    //     threadShow: false,
+    //     threadMessages: [],
+    //   }
+    // })
+
+    const pageSize = 10;
+    let temp;
+    const res_1 = await $axios.get(
+      `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
+    )
+
+    temp = {
+      messages: res_1.data.messages,
+      page: 1,
+      pageSize: pageSize,
+      displayMessages: res_1.data.messages.slice(0, pageSize),
+      pageLength: Math.ceil(res_1.data.messages.length / pageSize),
+      threadShow: false,
+      threadMessages: [],
+    }
+
+    // return temp;
+
+    // return temp;
+    // console.log(temp);
+    temp.displayMessages = await replaceMessages(temp.displayMessages);
+    console.log(replaceMessages(temp.displayMessages));
+    console.log('----------------------------------------------');
+    // console.log(temp.displayMessages);
+    console.log('----------------------------------------------');
+
+    return temp;
+
+    // console.log(temp.displayMessages)
+    // console.log(temp);
+
+    cache = { Uhogehoge: { name: 'swd' } }
+
+    return temp;
+
     async function replaceMessages(displayMessages) {
       let abc = displayMessages;
-      // console.log(abc);
       const userMentionRegex = /<@[A-Z0-9]+?>/gm;
-      displayMessages.forEach(async(message, i ) => {
+      displayMessages.forEach(async (message, i) => {
         let sendingUser = await getUserName(message.user);
 
         let userIds = message.text.match(userMentionRegex);
         if(userIds){
-          userIds.forEach( async (userId) => {
+          userIds.forEach(async (userId) => {
             let userName = await getUserName(userId.substring(2, userId.length-1))
-            // console.log(userName);
+            console.log(userName);
             message.text = "<" + sendingUser + ">" + message.text.replace(userId, '@'+userName)
             abc[i].text = message.text;
-            console.log(abc[i].text);
           });
         }
       });
-      console.log(abc[0].text);
-      // await sleep(5000);
+      return abc;
     }
 
-    function getUserName(userId){
-      return $axios.get(
+    async function getUserName(userId){
+      return await $axios.get(
         `https://slack.com/api/users.info?token=${process.env.SLACK_API_TOKEN}&user=${userId}`)
         .then(response => {
-          // console.log(response);
           if(response.data.ok == false) {
             alert(response.data.error)
             return;
           }
-          // console.log(response.data.user.profile.display_name);
+          // console.log( response.data.user.profile.display_name);
           return response.data.user.profile.display_name;
         })
         .catch(error => alert(error));
     }
-
-    const res = await $axios.get(
-      `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
-    )
-    const pageSize = 10;
-    let temp = {
-      messages: res.data.messages,
-      page: 1,
-      pageSize: pageSize,
-      displayMessages: res.data.messages.slice(0, pageSize),
-      pageLength: Math.ceil(res.data.messages.length / pageSize),
-      threadShow: false,
-      threadMessages: [],
-    }
-    // return temp;
-
-    temp.displayMessages = await replaceMessages(temp.displayMessages);
-    // console.log(temp.displayMessages);
-
-    return temp;
-
-    return await $axios.get(
-      `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
-    ).then((res) => {
-
-      return {
-        messages: res.data.messages,
-        page: 1,
-        pageSize: pageSize,
-        displayMessages: res.data.messages.slice(0, pageSize),
-        pageLength: Math.ceil(res.data.messages.length / pageSize),
-        threadShow: false,
-        threadMessages: [],
-      }
-    }).then((info) => {
-      replaceMessages(info.displayMessages);
-      return info;
-    })
   },
 
   data: () => ({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <v-layout>
     <v-flex>
       <message-card
-        v-for="message in displayMessages"
+        v-for="message in this.replaceMessages(displayMessages)"
         v-bind:message="message"
         v-bind:isThread=false
         v-bind:key="message.ts"
@@ -85,6 +85,37 @@ export default {
   },
 
   methods: {
+    replaceMessages(displayMessages) {
+      // return displayMessages;
+      const userMentionRegex = /<@[A-Z0-9]+?>/gm;
+      displayMessages.forEach((message) => {
+        let sendingUser = this.getUserName(message.user);
+
+        let userIds = message.text.match(userMentionRegex);
+        if(userIds){
+          userIds.forEach((userId) => {
+            let userName = this.getUserName(userId.substring(2, userId.length-1))
+            message.text = "<" + sendingUser + ">" + message.text.replace(userId, '@'+userName)
+          });
+        }
+      });
+      return displayMessages
+    },
+
+    getUserName(userId){
+      return　this.$axios.get(
+        `https://slack.com/api/users.info?token=${process.env.SLACK_API_TOKEN}&user=${userId}`)
+        .then(response => {
+          // console.log(response);
+          if(response.data.ok == false) {
+            alert(response.data.error)
+            return;
+          }
+          return response.data.user.profile.display_name;
+        })
+        .catch(error => alert(error));
+    },
+
     selectPage(selectedPage) {
       this.page = selectedPage;
       this.displayMessages = this.messages.slice((this.page - 1) * 10, this.pageSize * this.page)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -73,6 +73,12 @@ export default {
       `https://slack.com/api/conversations.history?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
     )
 
+    const aaa = await $axios.get(
+      `https://slack.com/api/users.list?token=${process.env.SLACK_API_TOKEN}&channel=${process.env.CHANNEL_ID}`
+    )
+
+    console.log(aaa.data.members.length);
+
     temp = {
       messages: res_1.data.messages,
       page: 1,
@@ -83,15 +89,11 @@ export default {
       threadMessages: [],
     }
 
-    // return temp;
-
-    // return temp;
-    // console.log(temp);
-    temp.displayMessages = await replaceMessages(temp.displayMessages);
-    console.log(replaceMessages(temp.displayMessages));
-    console.log('----------------------------------------------');
-    // console.log(temp.displayMessages);
-    console.log('----------------------------------------------');
+    let a = await replaceMessages(temp.displayMessages);
+    temp.displayMessages = a;
+    // console.log(replaceMessages(temp.displayMessages));
+    // console.log('----------------------------------------------');
+    // console.log('----------------------------------------------');
 
     return temp;
 


### PR DESCRIPTION
## 概要
- メッセージにメンション相手がいる際にもともとそのuser ID で表示されていたものをUserの名前を出すようにした。
- メンション相手がサブチーム(ex. @rx-dev)の場合はそのサブチームに向けたメンションだということがわかるようにした。
- メンション先は緑のハイライトかつ、boldを使ってメッセージとの区別をわかりやすくした。
- 送信元のuserも誰なのかわかるようにした。

## 機能追加の背景
- 送信先、送信元がわからなくて不便だった。

## 実装方法

### 前提
1.  メッセージの配列の中には送信元であるユーザーIDが入っている。[ref](https://api.slack.com/methods/channels.history)
2. メッセージの本文にメンション相手がいる場合本文中にそのユーザー達のIDが入っている。[ref](https://api.slack.com/methods/users.list)

### 実装方法
- slackのユーザーの一覧をとる。
- メッセージのメンション先、送信元を取り出して、ユーザーの一覧からユーザー名を取り出す。
- 取り出したユーザー名を適切なフォーマットにしてブラウザ上に表示する。


仕様用件など：[仕様用件](https://github.com/takuuuu517/nuxt-sample-app/issues/6)

